### PR TITLE
Implemented support to handle multiple rpc requests at the same time

### DIFF
--- a/trafficlight/trafficlight.py
+++ b/trafficlight/trafficlight.py
@@ -25,12 +25,18 @@ class TrafficReceiver:
         except json.JSONDecodeError:
             return web.Response(status=400, text="bad json")
 
-        try:
+        async def _handle_data(data: dict):
             model = RequestModel(**data)
+            await TrafficReceiver.process_data(model)
+
+        try:
+            if isinstance(data, list):
+                for entry in data:
+                    await _handle_data(entry)
+            else:
+                await _handle_data(data)
         except ValidationError as e:
             return web.Response(status=400, text=f"malformed data: {e}")
-
-        await TrafficReceiver.process_data(model)
 
         return web.Response(text="OK")
 


### PR DESCRIPTION
I find it extremely useful to dump a whole game session on a file and then load it on TrafficLight for analysis.

This pull requests allows to handle multiple RPC requests/responses being posted with a single HTTP request, easing the process of analysing big game dumps.