### PR TITLE
feat: allow population by field name

### DIFF
--- a/trafficlight/model.py
+++ b/trafficlight/model.py
@@ -6,9 +6,14 @@ class ProtoModel(BaseModel):
     request: str | None
     response: str | None = Field(alias="payload")
 
+    class Config:
+        allow_population_by_field_name = True
 
 class RequestModel(BaseModel):
     rpcid: int = 0
     rpchandle: int | None
     rpcstatus: int = 0
     protos: list[ProtoModel] = Field(alias="contents")
+
+    class Config:
+        allow_population_by_field_name = True


### PR DESCRIPTION
instead of introducing a new config for golbat raws we can just configure pydantic in the right way to allow population by field name as well as alias :) 

Tested this with my actual trafficlight setup and it works @ccev 